### PR TITLE
Porting OP-TEE driver for x86_64

### DIFF
--- a/Kconfig
+++ b/Kconfig
@@ -1,7 +1,7 @@
 # Generic Trusted Execution Environment Configuration
 config TEE
 	tristate "Trusted Execution Environment support"
-	depends on HAVE_ARM_SMCCC || COMPILE_TEST
+	depends on HAVE_ARM_SMCCC || COMPILE_TEST || X86_64
 	select DMA_SHARED_BUFFER
 	select GENERIC_ALLOCATOR
 	help

--- a/optee/Kconfig
+++ b/optee/Kconfig
@@ -1,7 +1,7 @@
 # OP-TEE Trusted Execution Environment Configuration
 config OPTEE
 	tristate "OP-TEE"
-	depends on HAVE_ARM_SMCCC
+	depends on HAVE_ARM_SMCCC || X86_64
 	help
 	  This implements the OP-TEE Trusted Execution Environment (TEE)
 	  driver.

--- a/optee/call.c
+++ b/optee/call.c
@@ -541,6 +541,9 @@ static bool is_normal_memory(pgprot_t p)
 	return (pgprot_val(p) & L_PTE_MT_MASK) == L_PTE_MT_WRITEALLOC;
 #elif defined(CONFIG_ARM64)
 	return (pgprot_val(p) & PTE_ATTRINDX_MASK) == PTE_ATTRINDX(MT_NORMAL);
+#elif defined(CONFIG_X86_64)
+	//TODO: will figure out how to implement it on x86 platform, return true for now.
+	return true;
 #else
 #error "Unuspported architecture"
 #endif


### PR DESCRIPTION
On Intel x86_64 platform, OP-TEE running is based on hypervisor. So vmcall
will be used to implement SMC call functionality.

Signed-off-by: Jingdong Lu <jingdong.lu@intel.com>