### PR TITLE
The return value of ioctl() returns a non-zero value when the open se…

### DIFF
--- a/optee/call.c
+++ b/optee/call.c
@@ -267,6 +267,7 @@ int optee_open_session(struct tee_context *ctx,
 		mutex_unlock(&ctxdata->mutex);
 	} else {
 		kfree(sess);
+		rc = -1;
 	}
 
 	if (optee_from_msg_param(param, arg->num_params, msg_arg->params + 2)) {


### PR DESCRIPTION
…ssion fails.

When the open session fails, the ioctl does not need to indicate a successful return.